### PR TITLE
run services as unpriviliged user www-data

### DIFF
--- a/Installatie-script Linux/services/upstart/WAD-Collector.conf
+++ b/Installatie-script Linux/services/upstart/WAD-Collector.conf
@@ -15,7 +15,7 @@ pre-start script
     test -e /opt/WAD_Services/WAD_Collector/dist/WAD_Collector.jar || { stop; exit 0; }
 end script
 
-exec java -jar WAD_Collector.jar
+exec sudo -u www-data java -jar WAD_Collector.jar
 
 post-start exec touch /var/run/WAD-Collector
 

--- a/Installatie-script Linux/services/upstart/WAD-Processor.conf
+++ b/Installatie-script Linux/services/upstart/WAD-Processor.conf
@@ -15,7 +15,7 @@ pre-start script
     test -e /opt/WAD_Services/WAD_Processor/dist/WAD_Processor.jar || { stop; exit 0; }
 end script
 
-exec java -jar WAD_Processor.jar
+exec sudo -u www-data java -jar WAD_Processor.jar
 
 post-start exec touch /var/run/WAD-Processor
 

--- a/Installatie-script Linux/services/upstart/WAD-Selector.conf
+++ b/Installatie-script Linux/services/upstart/WAD-Selector.conf
@@ -15,7 +15,7 @@ pre-start script
     test -e /opt/WAD_Services/WAD_Selector/dist/WAD_Selector.jar || { stop; exit 0; }
 end script
 
-exec java -jar WAD_Selector.jar
+exec sudo -u www-data java -jar WAD_Selector.jar
 
 post-start exec touch /var/run/WAD-Selector
 


### PR DESCRIPTION
Security Fix: Met deze modificatie zijn de linux startup scripts (voor Ubuntu) gelijk aan de sysvinit scripts (voor debian) qua user-rights, en worden de services niet langer gedraaid als root